### PR TITLE
Make epg<-->network relationship an association instead of a child->parent

### DIFF
--- a/appProfile.json
+++ b/appProfile.json
@@ -4,17 +4,11 @@
 		{
 			"name": "appProfile",
 			"type": "object",
-			"key": [ "tenantName", "networkName", "appProfileName" ],
+			"key": [ "tenantName", "appProfileName" ],
 			"properties": {
 				"tenantName": {
 					"type": "string",
 					"title": "Tenant Name",
-					"length": 64,
-					"format": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\\\-]*[a-zA-Z0-9])\\\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\\\-]*[A-Za-z0-9])$"
-				},
-				"networkName": {
-					"type": "string",
-					"title": "Network of App Prof",
 					"length": 64,
 					"format": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\\\-]*[a-zA-Z0-9])\\\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\\\-]*[A-Za-z0-9])$"
 				},
@@ -38,9 +32,6 @@
 			"links": {
 				"tenant": {
 					"ref": "tenant"
-				},
-				"network": {
-					"ref": "network"
 				}
 			}
 		}

--- a/client/contivModel.js
+++ b/client/contivModel.js
@@ -12,7 +12,7 @@ var AppProfileSummaryView = React.createClass({
 				<ModalTrigger modal={<AppProfileModalView appProfile={ appProfile }/>}>
 					<tr key={ appProfile.key } className="info">
 						
-						    
+						   
 					</tr>
 				</ModalTrigger>
 			);
@@ -24,7 +24,7 @@ var AppProfileSummaryView = React.createClass({
 				<thead>
 					<tr>
 					
-					    
+					   
 					</tr>
 				</thead>
 				<tbody>
@@ -47,8 +47,6 @@ var AppProfileModalView = React.createClass({
 				<Input type='text' label='Application Profile Name' ref='appProfileName' defaultValue={obj.appProfileName} placeholder='Application Profile Name' />
 			
 				<Input type='text' label='Member groups of the appProf' ref='endpointGroups' defaultValue={obj.endpointGroups} placeholder='Member groups of the appProf' />
-			
-				<Input type='text' label='Network of App Prof' ref='networkName' defaultValue={obj.networkName} placeholder='Network of App Prof' />
 			
 				<Input type='text' label='Tenant Name' ref='tenantName' defaultValue={obj.tenantName} placeholder='Tenant Name' />
 			

--- a/client/contivModelClient.go
+++ b/client/contivModelClient.go
@@ -152,8 +152,7 @@ type AppProfile struct {
 
 	AppProfileName string   `json:"appProfileName,omitempty"` // Application Profile Name
 	EndpointGroups []string `json:"endpointGroups,omitempty"`
-	NetworkName    string   `json:"networkName,omitempty"` // Network of App Prof
-	TenantName     string   `json:"tenantName,omitempty"`  // Tenant Name
+	TenantName     string   `json:"tenantName,omitempty"` // Tenant Name
 
 	// add link-sets and links
 	LinkSets AppProfileLinkSets `json:"link-sets,omitempty"`
@@ -165,8 +164,7 @@ type AppProfileLinkSets struct {
 }
 
 type AppProfileLinks struct {
-	Network Link `json:"Network,omitempty"`
-	Tenant  Link `json:"Tenant,omitempty"`
+	Tenant Link `json:"Tenant,omitempty"`
 }
 
 type Bgp struct {
@@ -237,7 +235,6 @@ type Network struct {
 }
 
 type NetworkLinkSets struct {
-	AppProfiles    map[string]Link `json:"AppProfiles,omitempty"`
 	EndpointGroups map[string]Link `json:"EndpointGroups,omitempty"`
 	Servicelbs     map[string]Link `json:"Servicelbs,omitempty"`
 	Services       map[string]Link `json:"Services,omitempty"`
@@ -386,7 +383,7 @@ type VolumeProfileLinks struct {
 // AppProfilePost posts the appProfile object
 func (c *ContivClient) AppProfilePost(obj *AppProfile) error {
 	// build key and URL
-	keyStr := obj.TenantName + ":" + obj.NetworkName + ":" + obj.AppProfileName
+	keyStr := obj.TenantName + ":" + obj.AppProfileName
 	url := c.baseURL + "/api/appProfiles/" + keyStr + "/"
 
 	// http post the object
@@ -416,9 +413,9 @@ func (c *ContivClient) AppProfileList() (*[]*AppProfile, error) {
 }
 
 // AppProfileGet gets the appProfile object
-func (c *ContivClient) AppProfileGet(tenantName string, networkName string, appProfileName string) (*AppProfile, error) {
+func (c *ContivClient) AppProfileGet(tenantName string, appProfileName string) (*AppProfile, error) {
 	// build key and URL
-	keyStr := tenantName + ":" + networkName + ":" + appProfileName
+	keyStr := tenantName + ":" + appProfileName
 	url := c.baseURL + "/api/appProfiles/" + keyStr + "/"
 
 	// http get the object
@@ -433,9 +430,9 @@ func (c *ContivClient) AppProfileGet(tenantName string, networkName string, appP
 }
 
 // AppProfileDelete deletes the appProfile object
-func (c *ContivClient) AppProfileDelete(tenantName string, networkName string, appProfileName string) error {
+func (c *ContivClient) AppProfileDelete(tenantName string, appProfileName string) error {
 	// build key and URL
-	keyStr := tenantName + ":" + networkName + ":" + appProfileName
+	keyStr := tenantName + ":" + appProfileName
 	url := c.baseURL + "/api/appProfiles/" + keyStr + "/"
 
 	// http get the object
@@ -516,7 +513,7 @@ func (c *ContivClient) BgpDelete(hostname string) error {
 // EndpointGroupPost posts the endpointGroup object
 func (c *ContivClient) EndpointGroupPost(obj *EndpointGroup) error {
 	// build key and URL
-	keyStr := obj.TenantName + ":" + obj.NetworkName + ":" + obj.GroupName
+	keyStr := obj.TenantName + ":" + obj.GroupName
 	url := c.baseURL + "/api/endpointGroups/" + keyStr + "/"
 
 	// http post the object
@@ -546,9 +543,9 @@ func (c *ContivClient) EndpointGroupList() (*[]*EndpointGroup, error) {
 }
 
 // EndpointGroupGet gets the endpointGroup object
-func (c *ContivClient) EndpointGroupGet(tenantName string, networkName string, groupName string) (*EndpointGroup, error) {
+func (c *ContivClient) EndpointGroupGet(tenantName string, groupName string) (*EndpointGroup, error) {
 	// build key and URL
-	keyStr := tenantName + ":" + networkName + ":" + groupName
+	keyStr := tenantName + ":" + groupName
 	url := c.baseURL + "/api/endpointGroups/" + keyStr + "/"
 
 	// http get the object
@@ -563,9 +560,9 @@ func (c *ContivClient) EndpointGroupGet(tenantName string, networkName string, g
 }
 
 // EndpointGroupDelete deletes the endpointGroup object
-func (c *ContivClient) EndpointGroupDelete(tenantName string, networkName string, groupName string) error {
+func (c *ContivClient) EndpointGroupDelete(tenantName string, groupName string) error {
 	// build key and URL
-	keyStr := tenantName + ":" + networkName + ":" + groupName
+	keyStr := tenantName + ":" + groupName
 	url := c.baseURL + "/api/endpointGroups/" + keyStr + "/"
 
 	// http get the object

--- a/client/contivModelClient.py
+++ b/client/contivModelClient.py
@@ -74,12 +74,11 @@ class objmodelClient:
 		self.baseUrl = baseUrl
 	# Create appProfile
 	def createAppProfile(self, obj):
-	    postUrl = self.baseUrl + '/api/appProfiles/' + obj.tenantName + ":" + obj.networkName + ":" + obj.appProfileName  + '/'
+	    postUrl = self.baseUrl + '/api/appProfiles/' + obj.tenantName + ":" + obj.appProfileName  + '/'
 
 	    jdata = json.dumps({ 
 			"appProfileName": obj.appProfileName, 
 			"endpointGroups": obj.endpointGroups, 
-			"networkName": obj.networkName, 
 			"tenantName": obj.tenantName, 
 	    })
 
@@ -90,9 +89,9 @@ class objmodelClient:
 	        errorExit("AppProfile create failure")
 
 	# Delete appProfile
-	def deleteAppProfile(self, tenantName, networkName, appProfileName):
+	def deleteAppProfile(self, tenantName, appProfileName):
 	    # Delete AppProfile
-	    deleteUrl = self.baseUrl + '/api/appProfiles/' + tenantName + ":" + networkName + ":" + appProfileName  + '/'
+	    deleteUrl = self.baseUrl + '/api/appProfiles/' + tenantName + ":" + appProfileName  + '/'
 	    response = httpDelete(deleteUrl)
 
 	    if response == "Error":
@@ -143,7 +142,7 @@ class objmodelClient:
 	    return json.loads(retData)
 	# Create endpointGroup
 	def createEndpointGroup(self, obj):
-	    postUrl = self.baseUrl + '/api/endpointGroups/' + obj.tenantName + ":" + obj.networkName + ":" + obj.groupName  + '/'
+	    postUrl = self.baseUrl + '/api/endpointGroups/' + obj.tenantName + ":" + obj.groupName  + '/'
 
 	    jdata = json.dumps({ 
 			"groupName": obj.groupName, 
@@ -159,9 +158,9 @@ class objmodelClient:
 	        errorExit("EndpointGroup create failure")
 
 	# Delete endpointGroup
-	def deleteEndpointGroup(self, tenantName, networkName, groupName):
+	def deleteEndpointGroup(self, tenantName, groupName):
 	    # Delete EndpointGroup
-	    deleteUrl = self.baseUrl + '/api/endpointGroups/' + tenantName + ":" + networkName + ":" + groupName  + '/'
+	    deleteUrl = self.baseUrl + '/api/endpointGroups/' + tenantName + ":" + groupName  + '/'
 	    response = httpDelete(deleteUrl)
 
 	    if response == "Error":

--- a/contivModel.go
+++ b/contivModel.go
@@ -21,8 +21,7 @@ type AppProfile struct {
 
 	AppProfileName string   `json:"appProfileName,omitempty"` // Application Profile Name
 	EndpointGroups []string `json:"endpointGroups,omitempty"`
-	NetworkName    string   `json:"networkName,omitempty"` // Network of App Prof
-	TenantName     string   `json:"tenantName,omitempty"`  // Tenant Name
+	TenantName     string   `json:"tenantName,omitempty"` // Tenant Name
 
 	// add link-sets and links
 	LinkSets AppProfileLinkSets `json:"link-sets,omitempty"`
@@ -34,8 +33,7 @@ type AppProfileLinkSets struct {
 }
 
 type AppProfileLinks struct {
-	Network modeldb.Link `json:"Network,omitempty"`
-	Tenant  modeldb.Link `json:"Tenant,omitempty"`
+	Tenant modeldb.Link `json:"Tenant,omitempty"`
 }
 
 type Bgp struct {
@@ -106,7 +104,6 @@ type Network struct {
 }
 
 type NetworkLinkSets struct {
-	AppProfiles    map[string]modeldb.Link `json:"AppProfiles,omitempty"`
 	EndpointGroups map[string]modeldb.Link `json:"EndpointGroups,omitempty"`
 	Servicelbs     map[string]modeldb.Link `json:"Servicelbs,omitempty"`
 	Services       map[string]modeldb.Link `json:"Services,omitempty"`
@@ -800,7 +797,7 @@ func restoreAppProfile() error {
 // Validate a appProfile object
 func ValidateAppProfile(obj *AppProfile) error {
 	// Validate key is correct
-	keyStr := obj.TenantName + ":" + obj.NetworkName + ":" + obj.AppProfileName
+	keyStr := obj.TenantName + ":" + obj.AppProfileName
 	if obj.Key != keyStr {
 		log.Errorf("Expecting AppProfile Key: %s. Got: %s", keyStr, obj.Key)
 		return errors.New("Invalid Key")
@@ -815,15 +812,6 @@ func ValidateAppProfile(obj *AppProfile) error {
 	appProfileNameMatch := regexp.MustCompile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$")
 	if appProfileNameMatch.MatchString(obj.AppProfileName) == false {
 		return errors.New("appProfileName string invalid format")
-	}
-
-	if len(obj.NetworkName) > 64 {
-		return errors.New("networkName string too long")
-	}
-
-	networkNameMatch := regexp.MustCompile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$")
-	if networkNameMatch.MatchString(obj.NetworkName) == false {
-		return errors.New("networkName string invalid format")
 	}
 
 	if len(obj.TenantName) > 64 {
@@ -1340,7 +1328,7 @@ func restoreEndpointGroup() error {
 // Validate a endpointGroup object
 func ValidateEndpointGroup(obj *EndpointGroup) error {
 	// Validate key is correct
-	keyStr := obj.TenantName + ":" + obj.NetworkName + ":" + obj.GroupName
+	keyStr := obj.TenantName + ":" + obj.GroupName
 	if obj.Key != keyStr {
 		log.Errorf("Expecting EndpointGroup Key: %s. Got: %s", keyStr, obj.Key)
 		return errors.New("Invalid Key")

--- a/endpointGroup.json
+++ b/endpointGroup.json
@@ -4,7 +4,7 @@
 		{
 			"name": "endpointGroup",
 			"type": "object",
-			"key": [ "tenantName", "networkName", "groupName" ],
+			"key": [ "tenantName", "groupName" ],
 			"properties": {
 				"groupName": {
 					"type": "string",

--- a/network.json
+++ b/network.json
@@ -67,9 +67,6 @@
 				"services": {
 					"ref": "service"
 				},
-				"appProfiles": {
-					"ref": "appProfile"
-				},
 				"endpointGroups": {
 					"ref": "endpointGroup"
 				},


### PR DESCRIPTION
EndpoindGroup key is now tenant:endpointgroup. AppProfile does not have a network property (it is indirectly associated with one or more networks via its member epg's).
