### PR TITLE
Support for external contracts (provided and consumed) for ACI

### DIFF
--- a/client/contivModel.js
+++ b/client/contivModel.js
@@ -218,6 +218,8 @@ var ExtContractsGroupSummaryView = React.createClass({
 						<td>{ extContractsGroup.contractsGroupName }</td>
 						 
 						<td>{ extContractsGroup.contractsType }</td>
+						 
+						<td>{ extContractsGroup.tenantName }</td>
 						
 					</tr>
 				</ModalTrigger>
@@ -232,7 +234,8 @@ var ExtContractsGroupSummaryView = React.createClass({
 					
 					  
 						<th> Contracts group name </th>  
-						<th> Contracts type </th> 
+						<th> Contracts type </th>  
+						<th> Tenant name </th> 
 					</tr>
 				</thead>
 				<tbody>
@@ -257,6 +260,8 @@ var ExtContractsGroupModalView = React.createClass({
 				<Input type='text' label='Contracts group name' ref='contractsGroupName' defaultValue={obj.contractsGroupName} placeholder='Contracts group name' />
 			
 				<Input type='text' label='Contracts type' ref='contractsType' defaultValue={obj.contractsType} placeholder='Contracts type' />
+			
+				<Input type='text' label='Tenant name' ref='tenantName' defaultValue={obj.tenantName} placeholder='Tenant name' />
 			
 			</div>
 	        <div className='modal-footer'>

--- a/client/contivModel.js
+++ b/client/contivModel.js
@@ -135,15 +135,13 @@ var EndpointGroupSummaryView = React.createClass({
 					<tr key={ endpointGroup.key } className="info">
 						
 						 
-						<td>{ endpointGroup.consExtContractsGrps }</td>
+						<td>{ endpointGroup.extContractsGrps }</td>
 						 
 						<td>{ endpointGroup.groupName }</td>
 						 
 						<td>{ endpointGroup.networkName }</td>
 						 
 						<td>{ endpointGroup.policies }</td>
-						 
-						<td>{ endpointGroup.provExtContractsGrps }</td>
 						 
 					</tr>
 				</ModalTrigger>
@@ -157,11 +155,10 @@ var EndpointGroupSummaryView = React.createClass({
 					<tr>
 					
 					 
-						<th> Consumed external contracts </th>  
+						<th> External contracts </th>  
 						<th> Group name </th>  
 						<th> Network </th>  
 						<th> Policies </th>  
-						<th> Provided external contracts </th>  
 					</tr>
 				</thead>
 				<tbody>
@@ -181,15 +178,13 @@ var EndpointGroupModalView = React.createClass({
 	        <div className='modal-body' style={ {margin: '5%',} }>
 			
 			
-				<Input type='text' label='Consumed external contracts' ref='consExtContractsGrps' defaultValue={obj.consExtContractsGrps} placeholder='Consumed external contracts' />
+				<Input type='text' label='External contracts' ref='extContractsGrps' defaultValue={obj.extContractsGrps} placeholder='External contracts' />
 			
 				<Input type='text' label='Group name' ref='groupName' defaultValue={obj.groupName} placeholder='Group name' />
 			
 				<Input type='text' label='Network' ref='networkName' defaultValue={obj.networkName} placeholder='Network' />
 			
 				<Input type='text' label='Policies' ref='policies' defaultValue={obj.policies} placeholder='Policies' />
-			
-				<Input type='text' label='Provided external contracts' ref='provExtContractsGrps' defaultValue={obj.provExtContractsGrps} placeholder='Provided external contracts' />
 			
 				<Input type='text' label='Tenant' ref='tenantName' defaultValue={obj.tenantName} placeholder='Tenant' />
 			

--- a/client/contivModel.js
+++ b/client/contivModel.js
@@ -135,11 +135,15 @@ var EndpointGroupSummaryView = React.createClass({
 					<tr key={ endpointGroup.key } className="info">
 						
 						 
+						<td>{ endpointGroup.consExtContractsGrps }</td>
+						 
 						<td>{ endpointGroup.groupName }</td>
 						 
 						<td>{ endpointGroup.networkName }</td>
 						 
 						<td>{ endpointGroup.policies }</td>
+						 
+						<td>{ endpointGroup.provExtContractsGrps }</td>
 						 
 					</tr>
 				</ModalTrigger>
@@ -153,9 +157,11 @@ var EndpointGroupSummaryView = React.createClass({
 					<tr>
 					
 					 
+						<th> Consumed external contracts </th>  
 						<th> Group name </th>  
 						<th> Network </th>  
 						<th> Policies </th>  
+						<th> Provided external contracts </th>  
 					</tr>
 				</thead>
 				<tbody>
@@ -175,11 +181,15 @@ var EndpointGroupModalView = React.createClass({
 	        <div className='modal-body' style={ {margin: '5%',} }>
 			
 			
+				<Input type='text' label='Consumed external contracts' ref='consExtContractsGrps' defaultValue={obj.consExtContractsGrps} placeholder='Consumed external contracts' />
+			
 				<Input type='text' label='Group name' ref='groupName' defaultValue={obj.groupName} placeholder='Group name' />
 			
 				<Input type='text' label='Network' ref='networkName' defaultValue={obj.networkName} placeholder='Network' />
 			
 				<Input type='text' label='Policies' ref='policies' defaultValue={obj.policies} placeholder='Policies' />
+			
+				<Input type='text' label='Provided external contracts' ref='provExtContractsGrps' defaultValue={obj.provExtContractsGrps} placeholder='Provided external contracts' />
 			
 				<Input type='text' label='Tenant' ref='tenantName' defaultValue={obj.tenantName} placeholder='Tenant' />
 			
@@ -194,6 +204,71 @@ var EndpointGroupModalView = React.createClass({
 
 module.exports.EndpointGroupSummaryView = EndpointGroupSummaryView
 module.exports.EndpointGroupModalView = EndpointGroupModalView
+var ExtContractsGroupSummaryView = React.createClass({
+  	render: function() {
+		var self = this
+
+		// Walk thru all objects
+		var extContractsGroupListView = self.props.extContractsGroups.map(function(extContractsGroup){
+			return (
+				<ModalTrigger modal={<ExtContractsGroupModalView extContractsGroup={ extContractsGroup }/>}>
+					<tr key={ extContractsGroup.key } className="info">
+						
+						  
+						<td>{ extContractsGroup.contractsGroupName }</td>
+						 
+						<td>{ extContractsGroup.contractsType }</td>
+						
+					</tr>
+				</ModalTrigger>
+			);
+		});
+
+		return (
+        <div>
+			<Table hover>
+				<thead>
+					<tr>
+					
+					  
+						<th> Contracts group name </th>  
+						<th> Contracts type </th> 
+					</tr>
+				</thead>
+				<tbody>
+            		{ extContractsGroupListView }
+				</tbody>
+			</Table>
+        </div>
+    	);
+	}
+});
+
+var ExtContractsGroupModalView = React.createClass({
+	render() {
+		var obj = this.props.extContractsGroup
+	    return (
+	      <Modal {...this.props} bsStyle='primary' bsSize='large' title='ExtContractsGroup' animation={false}>
+	        <div className='modal-body' style={ {margin: '5%',} }>
+			
+			
+				<Input type='text' label='Contracts list' ref='contracts' defaultValue={obj.contracts} placeholder='Contracts list' />
+			
+				<Input type='text' label='Contracts group name' ref='contractsGroupName' defaultValue={obj.contractsGroupName} placeholder='Contracts group name' />
+			
+				<Input type='text' label='Contracts type' ref='contractsType' defaultValue={obj.contractsType} placeholder='Contracts type' />
+			
+			</div>
+	        <div className='modal-footer'>
+				<Button onClick={this.props.onRequestHide}>Close</Button>
+	        </div>
+	      </Modal>
+	    );
+  	}
+});
+
+module.exports.ExtContractsGroupSummaryView = ExtContractsGroupSummaryView
+module.exports.ExtContractsGroupModalView = ExtContractsGroupModalView
 var GlobalSummaryView = React.createClass({
   	render: function() {
 		var self = this

--- a/client/contivModelClient.go
+++ b/client/contivModelClient.go
@@ -183,12 +183,11 @@ type EndpointGroup struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
 
-	ConsExtContractsGrps []string `json:"consExtContractsGrps,omitempty"`
-	GroupName            string   `json:"groupName,omitempty"`   // Group name
-	NetworkName          string   `json:"networkName,omitempty"` // Network
-	Policies             []string `json:"policies,omitempty"`
-	ProvExtContractsGrps []string `json:"provExtContractsGrps,omitempty"`
-	TenantName           string   `json:"tenantName,omitempty"` // Tenant
+	ExtContractsGrps []string `json:"extContractsGrps,omitempty"`
+	GroupName        string   `json:"groupName,omitempty"`   // Group name
+	NetworkName      string   `json:"networkName,omitempty"` // Network
+	Policies         []string `json:"policies,omitempty"`
+	TenantName       string   `json:"tenantName,omitempty"` // Tenant
 
 	// add link-sets and links
 	LinkSets EndpointGroupLinkSets `json:"link-sets,omitempty"`

--- a/client/contivModelClient.go
+++ b/client/contivModelClient.go
@@ -215,6 +215,7 @@ type ExtContractsGroup struct {
 	Contracts          []string `json:"contracts,omitempty"`
 	ContractsGroupName string   `json:"contractsGroupName,omitempty"` // Contracts group name
 	ContractsType      string   `json:"contractsType,omitempty"`      // Contracts type
+	TenantName         string   `json:"tenantName,omitempty"`         // Tenant name
 
 	// add link-sets and links
 	LinkSets ExtContractsGroupLinkSets `json:"link-sets,omitempty"`
@@ -598,7 +599,7 @@ func (c *ContivClient) EndpointGroupDelete(tenantName string, groupName string) 
 // ExtContractsGroupPost posts the extContractsGroup object
 func (c *ContivClient) ExtContractsGroupPost(obj *ExtContractsGroup) error {
 	// build key and URL
-	keyStr := obj.ContractsGroupName
+	keyStr := obj.TenantName + ":" + obj.ContractsGroupName
 	url := c.baseURL + "/api/extContractsGroups/" + keyStr + "/"
 
 	// http post the object
@@ -628,9 +629,9 @@ func (c *ContivClient) ExtContractsGroupList() (*[]*ExtContractsGroup, error) {
 }
 
 // ExtContractsGroupGet gets the extContractsGroup object
-func (c *ContivClient) ExtContractsGroupGet(contractsGroupName string) (*ExtContractsGroup, error) {
+func (c *ContivClient) ExtContractsGroupGet(tenantName string, contractsGroupName string) (*ExtContractsGroup, error) {
 	// build key and URL
-	keyStr := contractsGroupName
+	keyStr := tenantName + ":" + contractsGroupName
 	url := c.baseURL + "/api/extContractsGroups/" + keyStr + "/"
 
 	// http get the object
@@ -645,9 +646,9 @@ func (c *ContivClient) ExtContractsGroupGet(contractsGroupName string) (*ExtCont
 }
 
 // ExtContractsGroupDelete deletes the extContractsGroup object
-func (c *ContivClient) ExtContractsGroupDelete(contractsGroupName string) error {
+func (c *ContivClient) ExtContractsGroupDelete(tenantName string, contractsGroupName string) error {
 	// build key and URL
-	keyStr := contractsGroupName
+	keyStr := tenantName + ":" + contractsGroupName
 	url := c.baseURL + "/api/extContractsGroups/" + keyStr + "/"
 
 	// http get the object

--- a/client/contivModelClient.go
+++ b/client/contivModelClient.go
@@ -196,10 +196,9 @@ type EndpointGroup struct {
 }
 
 type EndpointGroupLinkSets struct {
-	ConsExtContractsGrps map[string]Link `json:"ConsExtContractsGrps,omitempty"`
-	Policies             map[string]Link `json:"Policies,omitempty"`
-	ProvExtContractsGrps map[string]Link `json:"ProvExtContractsGrps,omitempty"`
-	Services             map[string]Link `json:"Services,omitempty"`
+	ExtContractsGrps map[string]Link `json:"ExtContractsGrps,omitempty"`
+	Policies         map[string]Link `json:"Policies,omitempty"`
+	Services         map[string]Link `json:"Services,omitempty"`
 }
 
 type EndpointGroupLinks struct {

--- a/client/contivModelClient.go
+++ b/client/contivModelClient.go
@@ -183,10 +183,12 @@ type EndpointGroup struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
 
-	GroupName   string   `json:"groupName,omitempty"`   // Group name
-	NetworkName string   `json:"networkName,omitempty"` // Network
-	Policies    []string `json:"policies,omitempty"`
-	TenantName  string   `json:"tenantName,omitempty"` // Tenant
+	ConsExtContractsGrps []string `json:"consExtContractsGrps,omitempty"`
+	GroupName            string   `json:"groupName,omitempty"`   // Group name
+	NetworkName          string   `json:"networkName,omitempty"` // Network
+	Policies             []string `json:"policies,omitempty"`
+	ProvExtContractsGrps []string `json:"provExtContractsGrps,omitempty"`
+	TenantName           string   `json:"tenantName,omitempty"` // Tenant
 
 	// add link-sets and links
 	LinkSets EndpointGroupLinkSets `json:"link-sets,omitempty"`
@@ -194,14 +196,32 @@ type EndpointGroup struct {
 }
 
 type EndpointGroupLinkSets struct {
-	Policies map[string]Link `json:"Policies,omitempty"`
-	Services map[string]Link `json:"Services,omitempty"`
+	ConsExtContractsGrps map[string]Link `json:"ConsExtContractsGrps,omitempty"`
+	Policies             map[string]Link `json:"Policies,omitempty"`
+	ProvExtContractsGrps map[string]Link `json:"ProvExtContractsGrps,omitempty"`
+	Services             map[string]Link `json:"Services,omitempty"`
 }
 
 type EndpointGroupLinks struct {
 	AppProfile Link `json:"AppProfile,omitempty"`
 	Network    Link `json:"Network,omitempty"`
 	Tenant     Link `json:"Tenant,omitempty"`
+}
+
+type ExtContractsGroup struct {
+	// every object has a key
+	Key string `json:"key,omitempty"`
+
+	Contracts          []string `json:"contracts,omitempty"`
+	ContractsGroupName string   `json:"contractsGroupName,omitempty"` // Contracts group name
+	ContractsType      string   `json:"contractsType,omitempty"`      // Contracts type
+
+	// add link-sets and links
+	LinkSets ExtContractsGroupLinkSets `json:"link-sets,omitempty"`
+}
+
+type ExtContractsGroupLinkSets struct {
+	EndpointGroups map[string]Link `json:"EndpointGroups,omitempty"`
 }
 
 type Global struct {
@@ -569,6 +589,71 @@ func (c *ContivClient) EndpointGroupDelete(tenantName string, groupName string) 
 	err := httpDelete(url)
 	if err != nil {
 		log.Debugf("Error deleting endpointGroup %s. Err: %v", keyStr, err)
+		return err
+	}
+
+	return nil
+}
+
+// ExtContractsGroupPost posts the extContractsGroup object
+func (c *ContivClient) ExtContractsGroupPost(obj *ExtContractsGroup) error {
+	// build key and URL
+	keyStr := obj.ContractsGroupName
+	url := c.baseURL + "/api/extContractsGroups/" + keyStr + "/"
+
+	// http post the object
+	err := httpPost(url, obj)
+	if err != nil {
+		log.Debugf("Error creating extContractsGroup %+v. Err: %v", obj, err)
+		return err
+	}
+
+	return nil
+}
+
+// ExtContractsGroupList lists all extContractsGroup objects
+func (c *ContivClient) ExtContractsGroupList() (*[]*ExtContractsGroup, error) {
+	// build key and URL
+	url := c.baseURL + "/api/extContractsGroups/"
+
+	// http get the object
+	var objList []*ExtContractsGroup
+	err := httpGet(url, &objList)
+	if err != nil {
+		log.Debugf("Error getting extContractsGroups. Err: %v", err)
+		return nil, err
+	}
+
+	return &objList, nil
+}
+
+// ExtContractsGroupGet gets the extContractsGroup object
+func (c *ContivClient) ExtContractsGroupGet(contractsGroupName string) (*ExtContractsGroup, error) {
+	// build key and URL
+	keyStr := contractsGroupName
+	url := c.baseURL + "/api/extContractsGroups/" + keyStr + "/"
+
+	// http get the object
+	var obj ExtContractsGroup
+	err := httpGet(url, &obj)
+	if err != nil {
+		log.Debugf("Error getting extContractsGroup %+v. Err: %v", keyStr, err)
+		return nil, err
+	}
+
+	return &obj, nil
+}
+
+// ExtContractsGroupDelete deletes the extContractsGroup object
+func (c *ContivClient) ExtContractsGroupDelete(contractsGroupName string) error {
+	// build key and URL
+	keyStr := contractsGroupName
+	url := c.baseURL + "/api/extContractsGroups/" + keyStr + "/"
+
+	// http get the object
+	err := httpDelete(url)
+	if err != nil {
+		log.Debugf("Error deleting extContractsGroup %s. Err: %v", keyStr, err)
 		return err
 	}
 

--- a/client/contivModelClient.py
+++ b/client/contivModelClient.py
@@ -145,11 +145,10 @@ class objmodelClient:
 	    postUrl = self.baseUrl + '/api/endpointGroups/' + obj.tenantName + ":" + obj.groupName  + '/'
 
 	    jdata = json.dumps({ 
-			"consExtContractsGrps": obj.consExtContractsGrps, 
+			"extContractsGrps": obj.extContractsGrps, 
 			"groupName": obj.groupName, 
 			"networkName": obj.networkName, 
 			"policies": obj.policies, 
-			"provExtContractsGrps": obj.provExtContractsGrps, 
 			"tenantName": obj.tenantName, 
 	    })
 

--- a/client/contivModelClient.py
+++ b/client/contivModelClient.py
@@ -145,9 +145,11 @@ class objmodelClient:
 	    postUrl = self.baseUrl + '/api/endpointGroups/' + obj.tenantName + ":" + obj.groupName  + '/'
 
 	    jdata = json.dumps({ 
+			"consExtContractsGrps": obj.consExtContractsGrps, 
 			"groupName": obj.groupName, 
 			"networkName": obj.networkName, 
 			"policies": obj.policies, 
+			"provExtContractsGrps": obj.provExtContractsGrps, 
 			"tenantName": obj.tenantName, 
 	    })
 
@@ -172,6 +174,39 @@ class objmodelClient:
 	    retDate = urllib2.urlopen(self.baseUrl + '/api/endpointGroups/')
 	    if retData == "Error":
 	        errorExit("list EndpointGroup failed")
+
+	    return json.loads(retData)
+	# Create extContractsGroup
+	def createExtContractsGroup(self, obj):
+	    postUrl = self.baseUrl + '/api/extContractsGroups/' + obj.contractsGroupName  + '/'
+
+	    jdata = json.dumps({ 
+			"contracts": obj.contracts, 
+			"contractsGroupName": obj.contractsGroupName, 
+			"contractsType": obj.contractsType, 
+	    })
+
+	    # Post the data
+	    response = httpPost(postUrl, jdata)
+
+	    if response == "Error":
+	        errorExit("ExtContractsGroup create failure")
+
+	# Delete extContractsGroup
+	def deleteExtContractsGroup(self, contractsGroupName):
+	    # Delete ExtContractsGroup
+	    deleteUrl = self.baseUrl + '/api/extContractsGroups/' + contractsGroupName  + '/'
+	    response = httpDelete(deleteUrl)
+
+	    if response == "Error":
+	        errorExit("ExtContractsGroup create failure")
+
+	# List all extContractsGroup objects
+	def listExtContractsGroup(self):
+	    # Get a list of extContractsGroup objects
+	    retDate = urllib2.urlopen(self.baseUrl + '/api/extContractsGroups/')
+	    if retData == "Error":
+	        errorExit("list ExtContractsGroup failed")
 
 	    return json.loads(retData)
 	# Create global

--- a/client/contivModelClient.py
+++ b/client/contivModelClient.py
@@ -178,12 +178,13 @@ class objmodelClient:
 	    return json.loads(retData)
 	# Create extContractsGroup
 	def createExtContractsGroup(self, obj):
-	    postUrl = self.baseUrl + '/api/extContractsGroups/' + obj.contractsGroupName  + '/'
+	    postUrl = self.baseUrl + '/api/extContractsGroups/' + obj.tenantName + ":" + obj.contractsGroupName  + '/'
 
 	    jdata = json.dumps({ 
 			"contracts": obj.contracts, 
 			"contractsGroupName": obj.contractsGroupName, 
 			"contractsType": obj.contractsType, 
+			"tenantName": obj.tenantName, 
 	    })
 
 	    # Post the data
@@ -193,9 +194,9 @@ class objmodelClient:
 	        errorExit("ExtContractsGroup create failure")
 
 	# Delete extContractsGroup
-	def deleteExtContractsGroup(self, contractsGroupName):
+	def deleteExtContractsGroup(self, tenantName, contractsGroupName):
 	    # Delete ExtContractsGroup
-	    deleteUrl = self.baseUrl + '/api/extContractsGroups/' + contractsGroupName  + '/'
+	    deleteUrl = self.baseUrl + '/api/extContractsGroups/' + tenantName + ":" + contractsGroupName  + '/'
 	    response = httpDelete(deleteUrl)
 
 	    if response == "Error":

--- a/contivModel.go
+++ b/contivModel.go
@@ -52,12 +52,11 @@ type EndpointGroup struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
 
-	ConsExtContractsGrps []string `json:"consExtContractsGrps,omitempty"`
-	GroupName            string   `json:"groupName,omitempty"`   // Group name
-	NetworkName          string   `json:"networkName,omitempty"` // Network
-	Policies             []string `json:"policies,omitempty"`
-	ProvExtContractsGrps []string `json:"provExtContractsGrps,omitempty"`
-	TenantName           string   `json:"tenantName,omitempty"` // Tenant
+	ExtContractsGrps []string `json:"extContractsGrps,omitempty"`
+	GroupName        string   `json:"groupName,omitempty"`   // Group name
+	NetworkName      string   `json:"networkName,omitempty"` // Network
+	Policies         []string `json:"policies,omitempty"`
+	TenantName       string   `json:"tenantName,omitempty"` // Tenant
 
 	// add link-sets and links
 	LinkSets EndpointGroupLinkSets `json:"link-sets,omitempty"`

--- a/contivModel.go
+++ b/contivModel.go
@@ -1645,6 +1645,24 @@ func ValidateExtContractsGroup(obj *ExtContractsGroup) error {
 
 	// Validate each field
 
+	if len(obj.ContractsGroupName) > 64 {
+		return errors.New("contractsGroupName string too long")
+	}
+
+	contractsGroupNameMatch := regexp.MustCompile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$")
+	if contractsGroupNameMatch.MatchString(obj.ContractsGroupName) == false {
+		return errors.New("contractsGroupName string invalid format")
+	}
+
+	if len(obj.TenantName) > 64 {
+		return errors.New("tenantName string too long")
+	}
+
+	tenantNameMatch := regexp.MustCompile("^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$")
+	if tenantNameMatch.MatchString(obj.TenantName) == false {
+		return errors.New("tenantName string invalid format")
+	}
+
 	return nil
 }
 

--- a/contivModel.go
+++ b/contivModel.go
@@ -65,10 +65,9 @@ type EndpointGroup struct {
 }
 
 type EndpointGroupLinkSets struct {
-	ConsExtContractsGrps map[string]modeldb.Link `json:"ConsExtContractsGrps,omitempty"`
-	Policies             map[string]modeldb.Link `json:"Policies,omitempty"`
-	ProvExtContractsGrps map[string]modeldb.Link `json:"ProvExtContractsGrps,omitempty"`
-	Services             map[string]modeldb.Link `json:"Services,omitempty"`
+	ExtContractsGrps map[string]modeldb.Link `json:"ExtContractsGrps,omitempty"`
+	Policies         map[string]modeldb.Link `json:"Policies,omitempty"`
+	Services         map[string]modeldb.Link `json:"Services,omitempty"`
 }
 
 type EndpointGroupLinks struct {

--- a/contivModel.go
+++ b/contivModel.go
@@ -84,6 +84,7 @@ type ExtContractsGroup struct {
 	Contracts          []string `json:"contracts,omitempty"`
 	ContractsGroupName string   `json:"contractsGroupName,omitempty"` // Contracts group name
 	ContractsType      string   `json:"contractsType,omitempty"`      // Contracts type
+	TenantName         string   `json:"tenantName,omitempty"`         // Tenant name
 
 	// add link-sets and links
 	LinkSets ExtContractsGroupLinkSets `json:"link-sets,omitempty"`
@@ -1638,7 +1639,7 @@ func restoreExtContractsGroup() error {
 // Validate a extContractsGroup object
 func ValidateExtContractsGroup(obj *ExtContractsGroup) error {
 	// Validate key is correct
-	keyStr := obj.ContractsGroupName
+	keyStr := obj.TenantName + ":" + obj.ContractsGroupName
 	if obj.Key != keyStr {
 		log.Errorf("Expecting ExtContractsGroup Key: %s. Got: %s", keyStr, obj.Key)
 		return errors.New("Invalid Key")

--- a/contivModel.go
+++ b/contivModel.go
@@ -52,10 +52,12 @@ type EndpointGroup struct {
 	// every object has a key
 	Key string `json:"key,omitempty"`
 
-	GroupName   string   `json:"groupName,omitempty"`   // Group name
-	NetworkName string   `json:"networkName,omitempty"` // Network
-	Policies    []string `json:"policies,omitempty"`
-	TenantName  string   `json:"tenantName,omitempty"` // Tenant
+	ConsExtContractsGrps []string `json:"consExtContractsGrps,omitempty"`
+	GroupName            string   `json:"groupName,omitempty"`   // Group name
+	NetworkName          string   `json:"networkName,omitempty"` // Network
+	Policies             []string `json:"policies,omitempty"`
+	ProvExtContractsGrps []string `json:"provExtContractsGrps,omitempty"`
+	TenantName           string   `json:"tenantName,omitempty"` // Tenant
 
 	// add link-sets and links
 	LinkSets EndpointGroupLinkSets `json:"link-sets,omitempty"`
@@ -63,14 +65,32 @@ type EndpointGroup struct {
 }
 
 type EndpointGroupLinkSets struct {
-	Policies map[string]modeldb.Link `json:"Policies,omitempty"`
-	Services map[string]modeldb.Link `json:"Services,omitempty"`
+	ConsExtContractsGrps map[string]modeldb.Link `json:"ConsExtContractsGrps,omitempty"`
+	Policies             map[string]modeldb.Link `json:"Policies,omitempty"`
+	ProvExtContractsGrps map[string]modeldb.Link `json:"ProvExtContractsGrps,omitempty"`
+	Services             map[string]modeldb.Link `json:"Services,omitempty"`
 }
 
 type EndpointGroupLinks struct {
 	AppProfile modeldb.Link `json:"AppProfile,omitempty"`
 	Network    modeldb.Link `json:"Network,omitempty"`
 	Tenant     modeldb.Link `json:"Tenant,omitempty"`
+}
+
+type ExtContractsGroup struct {
+	// every object has a key
+	Key string `json:"key,omitempty"`
+
+	Contracts          []string `json:"contracts,omitempty"`
+	ContractsGroupName string   `json:"contractsGroupName,omitempty"` // Contracts group name
+	ContractsType      string   `json:"contractsType,omitempty"`      // Contracts type
+
+	// add link-sets and links
+	LinkSets ExtContractsGroupLinkSets `json:"link-sets,omitempty"`
+}
+
+type ExtContractsGroupLinkSets struct {
+	EndpointGroups map[string]modeldb.Link `json:"EndpointGroups,omitempty"`
 }
 
 type Global struct {
@@ -250,17 +270,18 @@ type VolumeProfileLinks struct {
 }
 
 type Collections struct {
-	appProfiles    map[string]*AppProfile
-	Bgps           map[string]*Bgp
-	endpointGroups map[string]*EndpointGroup
-	globals        map[string]*Global
-	networks       map[string]*Network
-	policys        map[string]*Policy
-	rules          map[string]*Rule
-	serviceLBs     map[string]*ServiceLB
-	tenants        map[string]*Tenant
-	volumes        map[string]*Volume
-	volumeProfiles map[string]*VolumeProfile
+	appProfiles        map[string]*AppProfile
+	Bgps               map[string]*Bgp
+	endpointGroups     map[string]*EndpointGroup
+	extContractsGroups map[string]*ExtContractsGroup
+	globals            map[string]*Global
+	networks           map[string]*Network
+	policys            map[string]*Policy
+	rules              map[string]*Rule
+	serviceLBs         map[string]*ServiceLB
+	tenants            map[string]*Tenant
+	volumes            map[string]*Volume
+	volumeProfiles     map[string]*VolumeProfile
 }
 
 var collections Collections
@@ -281,6 +302,12 @@ type EndpointGroupCallbacks interface {
 	EndpointGroupCreate(endpointGroup *EndpointGroup) error
 	EndpointGroupUpdate(endpointGroup, params *EndpointGroup) error
 	EndpointGroupDelete(endpointGroup *EndpointGroup) error
+}
+
+type ExtContractsGroupCallbacks interface {
+	ExtContractsGroupCreate(extContractsGroup *ExtContractsGroup) error
+	ExtContractsGroupUpdate(extContractsGroup, params *ExtContractsGroup) error
+	ExtContractsGroupDelete(extContractsGroup *ExtContractsGroup) error
 }
 
 type GlobalCallbacks interface {
@@ -332,17 +359,18 @@ type VolumeProfileCallbacks interface {
 }
 
 type CallbackHandlers struct {
-	AppProfileCb    AppProfileCallbacks
-	BgpCb           BgpCallbacks
-	EndpointGroupCb EndpointGroupCallbacks
-	GlobalCb        GlobalCallbacks
-	NetworkCb       NetworkCallbacks
-	PolicyCb        PolicyCallbacks
-	RuleCb          RuleCallbacks
-	ServiceLBCb     ServiceLBCallbacks
-	TenantCb        TenantCallbacks
-	VolumeCb        VolumeCallbacks
-	VolumeProfileCb VolumeProfileCallbacks
+	AppProfileCb        AppProfileCallbacks
+	BgpCb               BgpCallbacks
+	EndpointGroupCb     EndpointGroupCallbacks
+	ExtContractsGroupCb ExtContractsGroupCallbacks
+	GlobalCb            GlobalCallbacks
+	NetworkCb           NetworkCallbacks
+	PolicyCb            PolicyCallbacks
+	RuleCb              RuleCallbacks
+	ServiceLBCb         ServiceLBCallbacks
+	TenantCb            TenantCallbacks
+	VolumeCb            VolumeCallbacks
+	VolumeProfileCb     VolumeProfileCallbacks
 }
 
 var objCallbackHandler CallbackHandlers
@@ -351,6 +379,7 @@ func Init() {
 	collections.appProfiles = make(map[string]*AppProfile)
 	collections.Bgps = make(map[string]*Bgp)
 	collections.endpointGroups = make(map[string]*EndpointGroup)
+	collections.extContractsGroups = make(map[string]*ExtContractsGroup)
 	collections.globals = make(map[string]*Global)
 	collections.networks = make(map[string]*Network)
 	collections.policys = make(map[string]*Policy)
@@ -363,6 +392,7 @@ func Init() {
 	restoreAppProfile()
 	restoreBgp()
 	restoreEndpointGroup()
+	restoreExtContractsGroup()
 	restoreGlobal()
 	restoreNetwork()
 	restorePolicy()
@@ -384,6 +414,10 @@ func RegisterBgpCallbacks(handler BgpCallbacks) {
 
 func RegisterEndpointGroupCallbacks(handler EndpointGroupCallbacks) {
 	objCallbackHandler.EndpointGroupCb = handler
+}
+
+func RegisterExtContractsGroupCallbacks(handler ExtContractsGroupCallbacks) {
+	objCallbackHandler.ExtContractsGroupCb = handler
 }
 
 func RegisterGlobalCallbacks(handler GlobalCallbacks) {
@@ -486,6 +520,16 @@ func AddRoutes(router *mux.Router) {
 	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateEndpointGroup))
 	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateEndpointGroup))
 	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteEndpointGroup))
+
+	// Register extContractsGroup
+	route = "/api/extContractsGroups/{key}/"
+	listRoute = "/api/extContractsGroups/"
+	log.Infof("Registering %s", route)
+	router.Path(listRoute).Methods("GET").HandlerFunc(makeHttpHandler(httpListExtContractsGroups))
+	router.Path(route).Methods("GET").HandlerFunc(makeHttpHandler(httpGetExtContractsGroup))
+	router.Path(route).Methods("POST").HandlerFunc(makeHttpHandler(httpCreateExtContractsGroup))
+	router.Path(route).Methods("PUT").HandlerFunc(makeHttpHandler(httpCreateExtContractsGroup))
+	router.Path(route).Methods("DELETE").HandlerFunc(makeHttpHandler(httpDeleteExtContractsGroup))
 
 	// Register global
 	route = "/api/globals/{key}/"
@@ -1362,6 +1406,245 @@ func ValidateEndpointGroup(obj *EndpointGroup) error {
 	if tenantNameMatch.MatchString(obj.TenantName) == false {
 		return errors.New("tenantName string invalid format")
 	}
+
+	return nil
+}
+
+// LIST REST call
+func httpListExtContractsGroups(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpListExtContractsGroups: %+v", vars)
+
+	list := make([]*ExtContractsGroup, 0)
+	for _, obj := range collections.extContractsGroups {
+		list = append(list, obj)
+	}
+
+	// Return the list
+	return list, nil
+}
+
+// GET REST call
+func httpGetExtContractsGroup(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpGetExtContractsGroup: %+v", vars)
+
+	key := vars["key"]
+
+	obj := collections.extContractsGroups[key]
+	if obj == nil {
+		log.Errorf("extContractsGroup %s not found", key)
+		return nil, errors.New("extContractsGroup not found")
+	}
+
+	// Return the obj
+	return obj, nil
+}
+
+// CREATE REST call
+func httpCreateExtContractsGroup(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpGetExtContractsGroup: %+v", vars)
+
+	var obj ExtContractsGroup
+	key := vars["key"]
+
+	// Get object from the request
+	err := json.NewDecoder(r.Body).Decode(&obj)
+	if err != nil {
+		log.Errorf("Error decoding extContractsGroup create request. Err %v", err)
+		return nil, err
+	}
+
+	// set the key
+	obj.Key = key
+
+	// Create the object
+	err = CreateExtContractsGroup(&obj)
+	if err != nil {
+		log.Errorf("CreateExtContractsGroup error for: %+v. Err: %v", obj, err)
+		return nil, err
+	}
+
+	// Return the obj
+	return obj, nil
+}
+
+// DELETE rest call
+func httpDeleteExtContractsGroup(w http.ResponseWriter, r *http.Request, vars map[string]string) (interface{}, error) {
+	log.Debugf("Received httpDeleteExtContractsGroup: %+v", vars)
+
+	key := vars["key"]
+
+	// Delete the object
+	err := DeleteExtContractsGroup(key)
+	if err != nil {
+		log.Errorf("DeleteExtContractsGroup error for: %s. Err: %v", key, err)
+		return nil, err
+	}
+
+	// Return the obj
+	return key, nil
+}
+
+// Create a extContractsGroup object
+func CreateExtContractsGroup(obj *ExtContractsGroup) error {
+	// Validate parameters
+	err := ValidateExtContractsGroup(obj)
+	if err != nil {
+		log.Errorf("ValidateExtContractsGroup retruned error for: %+v. Err: %v", obj, err)
+		return err
+	}
+
+	// Check if we handle this object
+	if objCallbackHandler.ExtContractsGroupCb == nil {
+		log.Errorf("No callback registered for extContractsGroup object")
+		return errors.New("Invalid object type")
+	}
+
+	saveObj := obj
+
+	// Check if object already exists
+	if collections.extContractsGroups[obj.Key] != nil {
+		// Perform Update callback
+		err = objCallbackHandler.ExtContractsGroupCb.ExtContractsGroupUpdate(collections.extContractsGroups[obj.Key], obj)
+		if err != nil {
+			log.Errorf("ExtContractsGroupUpdate retruned error for: %+v. Err: %v", obj, err)
+			return err
+		}
+
+		// save the original object after update
+		saveObj = collections.extContractsGroups[obj.Key]
+	} else {
+		// save it in cache
+		collections.extContractsGroups[obj.Key] = obj
+
+		// Perform Create callback
+		err = objCallbackHandler.ExtContractsGroupCb.ExtContractsGroupCreate(obj)
+		if err != nil {
+			log.Errorf("ExtContractsGroupCreate retruned error for: %+v. Err: %v", obj, err)
+			delete(collections.extContractsGroups, obj.Key)
+			return err
+		}
+	}
+
+	// Write it to modeldb
+	err = saveObj.Write()
+	if err != nil {
+		log.Errorf("Error saving extContractsGroup %s to db. Err: %v", saveObj.Key, err)
+		return err
+	}
+
+	return nil
+}
+
+// Return a pointer to extContractsGroup from collection
+func FindExtContractsGroup(key string) *ExtContractsGroup {
+	obj := collections.extContractsGroups[key]
+	if obj == nil {
+		return nil
+	}
+
+	return obj
+}
+
+// Delete a extContractsGroup object
+func DeleteExtContractsGroup(key string) error {
+	obj := collections.extContractsGroups[key]
+	if obj == nil {
+		log.Errorf("extContractsGroup %s not found", key)
+		return errors.New("extContractsGroup not found")
+	}
+
+	// Check if we handle this object
+	if objCallbackHandler.ExtContractsGroupCb == nil {
+		log.Errorf("No callback registered for extContractsGroup object")
+		return errors.New("Invalid object type")
+	}
+
+	// Perform callback
+	err := objCallbackHandler.ExtContractsGroupCb.ExtContractsGroupDelete(obj)
+	if err != nil {
+		log.Errorf("ExtContractsGroupDelete retruned error for: %+v. Err: %v", obj, err)
+		return err
+	}
+
+	// delete it from modeldb
+	err = obj.Delete()
+	if err != nil {
+		log.Errorf("Error deleting extContractsGroup %s. Err: %v", obj.Key, err)
+	}
+
+	// delete it from cache
+	delete(collections.extContractsGroups, key)
+
+	return nil
+}
+
+func (self *ExtContractsGroup) GetType() string {
+	return "extContractsGroup"
+}
+
+func (self *ExtContractsGroup) GetKey() string {
+	return self.Key
+}
+
+func (self *ExtContractsGroup) Read() error {
+	if self.Key == "" {
+		log.Errorf("Empty key while trying to read extContractsGroup object")
+		return errors.New("Empty key")
+	}
+
+	return modeldb.ReadObj("extContractsGroup", self.Key, self)
+}
+
+func (self *ExtContractsGroup) Write() error {
+	if self.Key == "" {
+		log.Errorf("Empty key while trying to Write extContractsGroup object")
+		return errors.New("Empty key")
+	}
+
+	return modeldb.WriteObj("extContractsGroup", self.Key, self)
+}
+
+func (self *ExtContractsGroup) Delete() error {
+	if self.Key == "" {
+		log.Errorf("Empty key while trying to Delete extContractsGroup object")
+		return errors.New("Empty key")
+	}
+
+	return modeldb.DeleteObj("extContractsGroup", self.Key)
+}
+
+func restoreExtContractsGroup() error {
+	strList, err := modeldb.ReadAllObj("extContractsGroup")
+	if err != nil {
+		log.Errorf("Error reading extContractsGroup list. Err: %v", err)
+	}
+
+	for _, objStr := range strList {
+		// Parse the json model
+		var extContractsGroup ExtContractsGroup
+		err = json.Unmarshal([]byte(objStr), &extContractsGroup)
+		if err != nil {
+			log.Errorf("Error parsing object %s, Err %v", objStr, err)
+			return err
+		}
+
+		// add it to the collection
+		collections.extContractsGroups[extContractsGroup.Key] = &extContractsGroup
+	}
+
+	return nil
+}
+
+// Validate a extContractsGroup object
+func ValidateExtContractsGroup(obj *ExtContractsGroup) error {
+	// Validate key is correct
+	keyStr := obj.ContractsGroupName
+	if obj.Key != keyStr {
+		log.Errorf("Expecting ExtContractsGroup Key: %s. Got: %s", keyStr, obj.Key)
+		return errors.New("Invalid Key")
+	}
+
+	// Validate each field
 
 	return nil
 }

--- a/endpointGroup.json
+++ b/endpointGroup.json
@@ -56,13 +56,9 @@
 				"policies": {
 					"ref": "policy"
 				},
-                                "consExtContractsGrps": {
-                                        "ref": "extContractsGrp"
-                                },
-                                "provExtContractsGrps": {
+                                "extContractsGrps": {
                                         "ref": "extContractsGrp"
                                 }
-
 			},
 			"links": {
 				"tenant": {

--- a/endpointGroup.json
+++ b/endpointGroup.json
@@ -35,19 +35,12 @@
 					"Title": "Policies",
 					"ShowSummary": true
 				},
-				"consExtContractsGrps": {
+				"extContractsGrps": {
                                         "type": "array",
                                         "items": "string",
-                                        "Title": "Consumed external contracts",
-                                        "ShowSummary": true
-                                },
-                                "provExtContractsGrps": {
-                                        "type": "array",
-                                        "items": "string",
-                                        "Title": "Provided external contracts",
+                                        "Title": "External contracts",
                                         "ShowSummary": true
                                 }
-
 			},
 			"link-sets": {
 				"services": {

--- a/endpointGroup.json
+++ b/endpointGroup.json
@@ -34,7 +34,20 @@
 					"items": "string",
 					"Title": "Policies",
 					"ShowSummary": true
-				}
+				},
+				"consExtContractsGrps": {
+                                        "type": "array",
+                                        "items": "string",
+                                        "Title": "Consumed external contracts",
+                                        "ShowSummary": true
+                                },
+                                "provExtContractsGrps": {
+                                        "type": "array",
+                                        "items": "string",
+                                        "Title": "Provided external contracts",
+                                        "ShowSummary": true
+                                }
+
 			},
 			"link-sets": {
 				"services": {
@@ -42,7 +55,14 @@
 				},
 				"policies": {
 					"ref": "policy"
-				}
+				},
+                                "consExtContractsGrps": {
+                                        "ref": "extContractsGrp"
+                                },
+                                "provExtContractsGrps": {
+                                        "ref": "extContractsGrp"
+                                }
+
 			},
 			"links": {
 				"tenant": {

--- a/extContractsGroup.json
+++ b/extContractsGroup.json
@@ -1,35 +1,41 @@
 {
-	"name": "contivModel",
-	"objects": [
-		{
-			"name": "extContractsGroup",
-			"type": "object",
-			"key": [ "contractsGroupName" ],
-			"properties": {
-				"contractsGroupName": {
-					"type": "string",
-					"description": "Contracts group name",
-					"title": "Contracts group name",
-					"showSummary": true
-				},
-				"contractsType": {
-					"type": "string",
-					"description": "Contracts type (Provided -or- Consumed)",
-					"title": "Contracts type",
-					"showSummary": true
-				},
-				"contracts": {
-					"type": "array",
-					"items": "string",
-					"description": "List of contracts provided or consumed",
-					"title": "Contracts list"
+        "name": "contivModel",
+                "objects": [
+                {
+                        "name": "extContractsGroup",
+                        "type": "object",
+                        "key": [ "tenantName", "contractsGroupName" ],
+                        "properties": {
+                                "tenantName": {
+                                        "type": "string",
+                                        "title": "Tenant name",
+                                        "description": "Tenant name",
+                                        "showSummary": true
+                                },
+                                "contractsGroupName": {
+                                        "type": "string",
+                                        "description": "Contracts group name",
+                                        "title": "Contracts group name",
+                                        "showSummary": true
+                                },
+                                "contractsType": {
+                                        "type": "string",
+                                        "description": "Contracts type (Provided -or- Consumed)",
+                                        "title": "Contracts type",
+                                        "showSummary": true
+                                },
+                                "contracts": {
+                                        "type": "array",
+                                        "items": "string",
+                                        "description": "List of contracts provided or consumed",
+                                        "title": "Contracts list"
                                 }
-			},
-			"link-sets": {
-				"endpointGroups": {
-					"ref": "endpointGroup"
-				}
-			}
-		}
-	]
+                        },
+                        "link-sets": {
+                                "endpointGroups": {
+                                        "ref": "endpointGroup"
+                                }
+                        }
+                }
+        ]
 }

--- a/extContractsGroup.json
+++ b/extContractsGroup.json
@@ -7,16 +7,20 @@
                         "key": [ "tenantName", "contractsGroupName" ],
                         "properties": {
                                 "tenantName": {
-                                        "type": "string",
-                                        "title": "Tenant name",
-                                        "description": "Tenant name",
-                                        "showSummary": true
+					"type": "string",
+					"title": "Tenant name",
+					"description": "Tenant name",
+					"length": 64,
+					"format": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\\\-]*[a-zA-Z0-9])\\\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\\\-]*[A-Za-z0-9])$",
+					"showSummary": true
                                 },
                                 "contractsGroupName": {
-                                        "type": "string",
-                                        "description": "Contracts group name",
-                                        "title": "Contracts group name",
-                                        "showSummary": true
+					"type": "string",
+					"description": "Contracts group name",
+					"length": 64,
+					"format": "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\\\-]*[a-zA-Z0-9])\\\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\\\-]*[A-Za-z0-9])$",
+					"title": "Contracts group name",
+					"showSummary": true
                                 },
                                 "contractsType": {
                                         "type": "string",

--- a/extContractsGroup.json
+++ b/extContractsGroup.json
@@ -1,0 +1,35 @@
+{
+	"name": "contivModel",
+	"objects": [
+		{
+			"name": "extContractsGroup",
+			"type": "object",
+			"key": [ "contractsGroupName" ],
+			"properties": {
+				"contractsGroupName": {
+					"type": "string",
+					"description": "Contracts group name",
+					"title": "Contracts group name",
+					"showSummary": true
+				},
+				"contractsType": {
+					"type": "string",
+					"description": "Contracts type (Provided -or- Consumed)",
+					"title": "Contracts type",
+					"showSummary": true
+				},
+				"contracts": {
+					"type": "array",
+					"items": "string",
+					"description": "List of contracts provided or consumed",
+					"title": "Contracts list"
+                                }
+			},
+			"link-sets": {
+				"endpointGroups": {
+					"ref": "endpointGroup"
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
contivmodel changes for external contracts support. Please see related changes to netplugin and aci-gw repositories.
A new object is created to represent external contracts. The epg objects can refer to these objects during EPG create/update.
