### PR TITLE
Contiv spec auto-generation

### DIFF
--- a/spec/Dockerfile
+++ b/spec/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:alpine
+
+RUN npm install -g raml2html
+
+COPY . /contiv
+
+WORKDIR /contiv
+
+RUN raml2html -i contiv.raml -o contiv.html
+
+ENTRYPOINT ["/bin/sh"]

--- a/spec/Makefile
+++ b/spec/Makefile
@@ -1,0 +1,6 @@
+all: docs
+
+docs:
+	@./build.sh
+
+.PHONY: docs

--- a/spec/build.sh
+++ b/spec/build.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-docker build -t contiv/spec:latest .
-cid=$(docker run -itd contiv/spec:latest)
+docker build -t contiv/spec .
+cid=$(docker run -itd contiv/spec)
 docker cp ${cid}:/contiv/contiv.html .
 docker rm -f -v ${cid}

--- a/spec/build.sh
+++ b/spec/build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+docker build -t contiv/spec:latest .
+cid=$(docker run -itd contiv/spec:latest)
+docker cp ${cid}:/contiv/contiv.html .
+docker rm -f -v ${cid}

--- a/spec/contiv.raml
+++ b/spec/contiv.raml
@@ -1,0 +1,280 @@
+#%RAML 1.0
+title: Contiv
+description: Contiv API Specification
+version: v1
+baseUri:
+  value: http://{serverfqdn}:10000/api/{version}
+  (rediractable): true
+baseUriParameters:
+  serverfqdn:
+    type: string
+protocols: [  HTTPS ]
+mediaType: [ application/json ]
+
+resourceTypes:
+  collection: !include contiv/schemas/collection.raml
+  non-upd-collection-item: !include contiv/schemas/non-upd-collection-item.raml
+  collection-item: !include contiv/schemas/collection-item.raml
+  ro-collection-item: !include contiv/schemas/ro-collection-item.raml
+
+annotationTypes:
+  info:
+    properties:
+      license:
+        type: string
+        enum: [ "Apache 2.0" ]
+    allowedTargets: API
+  rediractable: boolean
+
+securitySchemes:
+  custom_scheme: !include contiv/schemas/custom-scheme.raml
+
+# Resource templates
+uses:
+  auth_proxy: contiv/libraries/auth_proxy.raml
+  netmaster: contiv/libraries/netmaster.raml
+
+securedBy: custom_scheme
+
+# auth_proxy endpoints
+/auth_proxy:
+  displayName: Auth API
+  description: Authentication/Authorization related API 
+
+  /version:
+    get:
+      securedBy: [ null ]
+      responses:
+        200:
+          body:
+            application/json: |
+              { "version": "1.0.0-beta" }
+
+  /health:
+    get:
+      securedBy: [ null ]
+      responses:
+        200:
+          body:
+            application/json:
+              type: auth_proxy.health
+
+
+  /login:
+    post:
+      description: Login to Contiv API server
+      securedBy: [ null ]
+      body:
+        application/json:
+          type: auth_proxy.login
+      responses:
+        200:
+          body:
+            application/json:
+              type: auth_proxy.login_response
+        400:
+        401:
+
+  /local_users:
+    type: {collection: {provider: auth_proxy}}
+    displayName: Local Users
+
+    /{username}:
+      type: {collection-item: {provider: auth_proxy}}
+      displayName: Local User
+
+  /ldap_configuration:
+    type: {collection-item: {provider: auth_proxy}}
+    displayName: LDAP Configuration
+    put:
+
+  /authorizations:
+    type: {collection: {provider: auth_proxy}}
+    displayName: Authorizations
+    
+    /{authzUUID}:
+      type: {non-upd-collection-item: {provider: auth_proxy}}
+      displayName: Authorization
+
+#Netmaster endpoints. Most of this can be auto-gen
+/inspect:
+  displayName: Inspect
+  description: Inspect APIs for various Contiv managed objects
+
+  /aciGws:
+    /aciGw:
+      type: {ro-collection-item: {provider: netmaster}}
+  /appProfiles:
+    /{appProfileName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /Bgps:
+    /{hostname}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /endpoints:
+    /{endpointID}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /endpointGroups:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{groupName}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /extContractsGroups:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{contractsGroupName}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /globals:
+    /global:
+      type: {ro-collection-item: {provider: netmaster}}
+  /netprofiles:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{profileName}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /networks:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{networkName}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /policys:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{policyName}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /rules:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{policyName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{ruleId}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /serviceLBs:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+    /{serviceName}:
+      type: {ro-collection-item: {provider: netmaster}}
+  /tenants:
+    /{tenantName}:
+      type: {ro-collection-item: {provider: netmaster}}
+
+/aciGws:
+  type: {collection: {provider: netmaster}}
+  displayName: ACI Gateways
+  description: ACI gateway settings
+
+  /aciGw:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/appProfiles:
+  type: {collection: {provider: netmaster}}
+  displayName: Application Profiles
+  
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+  /{appProfileName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/Bgps:
+  type: {collection: {provider: netmaster}}
+  displayName: BGP
+  description: BGP settings
+
+  /{hostname}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/endpointGroups:
+  type: {collection: {provider: netmaster}}
+  displayName: Endpoint Groups
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{groupName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/extContractsGroups:
+  type: {collection: {provider: netmaster}}
+  displayName: External Contract Groups
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{contractsGroupName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/globals:
+  type: {collection: {provider: netmaster}}
+  displayName: Globals
+  description: Contiv global settings
+  
+  /global:
+    type: {collection-item: {provider: netmaster}}
+    displayName: Global
+    put:
+
+/netprofiles:
+  type: {collection: {provider: netmaster}}
+  displayName: Network Profiles
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{profileName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/networks:
+  type: {collection: {provider: netmaster}}
+  displayName: Networks
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{networkName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/policys:
+  type: {collection: {provider: netmaster}}
+  displayName: Policies
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{policyName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/rules:
+  type: {collection: {provider: netmaster}}
+  displayName: Rules
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{policyName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{ruleId}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/serviceLBs:
+  type: {collection: {provider: netmaster}}
+  displayName: Service Load Balancers
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+  /{serviceName}:
+    type: {collection-item: {provider: netmaster}}
+    put:
+
+/tenants:
+  type: {collection: {provider: netmaster}}
+  displayName: Tenants
+  /{tenantName}:
+    type: {collection-item: {provider: netmaster}}
+    put:

--- a/spec/contiv/libraries/auth_proxy.raml
+++ b/spec/contiv/libraries/auth_proxy.raml
@@ -1,0 +1,126 @@
+#%RAML 1.0 Library
+types:
+  health:
+    properties:
+      status:
+        enum: [ "healthy", "unhealthy" ]
+      version: string
+      netmaster:
+        properties:
+          status:
+            enum: [ "healthy", "unhealthy" ]
+          reason: 
+            type: string
+            required: false
+            description: reason for netmaster being unhealthy
+          version: 
+            type: string
+            required: false
+            description: omitted in case netmaster is unhealthy
+    example: |
+      {"netmaster":{"status":"healthy","version":"pv1.0.0-alpha-01-27-2017.23-16-47.UTC"},"status":"healthy","version":"1.0.0-alpha"}
+      
+  ldap_configuration:
+    properties:
+      server:
+        type: string
+        description: FQDN or IP address of AD server
+        example: auth.local.com
+      port:
+        type: integer
+        format: int16
+        minimum: 0
+        description: port where AD server is listening
+        example: 389
+      base_dn: 
+        type: string
+        description: Distinguished name for base entity. All search queries will be scope to this BaseDN
+        example: ou=eng,dc=auth,dc=com
+      service_account_dn:
+        type: string
+        description: DN of the service account. auth_proxy will use this account to communicate with AD server. Hence this account must have appropriate privileges, specifically for lookup.
+      service_account_password:
+        type: string
+      start_tls:
+        type: boolean
+        description: switch session to TLS after proxy connects to AD server. This option must be configured on AD server. Recommended to set to true in production environments.
+      insecure_skip_verify:
+        type: boolean
+        description: skip cert check on AD server. Recommended to set to false for production environments.
+  upd_ldap_configuration:
+    type: ldap_configuration
+
+
+  local_user:
+    properties:
+      username: string
+      password: string
+      firstname: 
+        type: string
+        example: John
+        required: false
+      lastname:
+        type: string
+        example: Doe
+        required: false
+      disable:
+        type: boolean
+        required: false
+    example:
+      username: johndoe
+      password: p@ssw0rd
+  upd_local_user:
+    properties:
+      firstname: 
+        type: string
+        required: false
+      lastname: 
+        type: string
+        required: false
+      disable: 
+        type: boolean
+        required: false
+      password:
+        type: string
+        required: false
+    example:
+      firstname: Jane
+      disable: true
+  local_users:
+    type: array
+    items: 
+      type: local_user
+
+  login:
+    properties:
+      username:
+        type: string
+        description: user name. If a local user doesn't exist by that name, AD authentication will be tried using sAMAccountName=username in BaseDN scope of the AD server (see ldap configuration for more details)
+      password: string
+    example:
+      username: johndoe
+      password: p@ssw0rd
+  login_response:
+    properties:
+      token:
+        type: string
+        description: opaque token string, callers should set custom security header to this token before calling further APIs (see security information for protected APIs)
+
+
+  authorization:
+    properties:
+      principalName: string
+      local: boolean
+      role: string
+      tenantName: string
+    example:
+      principalName: johndoe
+      local: true
+      role: ops
+      tenantName: johnstenant
+  upd_authorization:
+    type: authorization
+  authorizations:
+    type: array
+    items:
+      type: authorization

--- a/spec/contiv/libraries/netmaster.raml
+++ b/spec/contiv/libraries/netmaster.raml
@@ -1,0 +1,696 @@
+#%RAML 1.0 Library
+types:
+  aciGw:
+    properties:
+      name:
+        type: string
+        maxLength: 64
+        description: name of this block(must be 'aciGw')
+        pattern: ^(aciGw)$
+      pathBindings:
+        type: string
+        maxLength: 2048
+        description: List of ACI fabric ports connected to cluster
+        pattern: ^$|^(topology/pod-[0-9]{1,4}/paths-[0-9]{1,4}/pathep-\\[eth[0-9]{1,2}/[0-9]{1,2}\\]){1}(,topology/pod-[0-9]{1,4}/paths-[0-9]{1,4}/pathep-\\[eth[0-9]{1,2}/[0-9]{1,2}\\])?$
+      nodeBindings:
+        type: string
+        maxLength: 2048
+        description: List of ACI complete nodes to be bound
+        pattern: ^$|^(topology/pod-[0-9]{1,4}/node-[0-9]{1,4}){1}(,topology/pod-[0-9]{1,4}/node-[0-9]{1,4})?$
+      physicalDomain:
+        type: string
+        maxLength: 128
+        description: Name of the physical domain
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      enforcePolicies:
+        type: string
+        maxLength: 64
+        description: Enforce security policy
+        pattern: ^(yes|no){1}$
+      includeCommonTenant:
+        type: string
+        maxLength: 64
+        description: Include common tenant when searching for objects
+        pattern: ^(yes|no){1}$
+  aciGws:
+    type: array
+    items:
+      type: aciGw
+  upd_aciGw:
+    type: aciGw
+  inspect_aciGw:
+    properties:
+      Config:
+        type: aciGw
+      Oper:
+        properties:
+          numAppProfiles:
+            type: integer
+  appProfile:
+    properties:
+      tenantName:
+        type: string
+        maxLength: 64
+        description: Tenant Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      appProfileName:
+        type: string
+        maxLength: 64
+        description: Application Profile Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      endpointGroups:
+        type: array
+        items:
+          type: string
+        description: Member groups of the appProf
+  appProfiles:
+    type: array
+    items:
+      type: appProfile
+  upd_appProfile:
+    type: appProfile
+  inspect_appProfile:
+    properties:
+      Config:
+        type: appProfile
+  Bgp:
+    properties:
+      hostname:
+        type: string
+        maxLength: 256
+        description: host name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      routerip:
+        type: string
+        description: Bgp router intf ip
+        pattern: ^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})(\\-(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))?/(3[0-1]|2[0-9]|1[0-9]|[1-9])$
+      as:
+        type: string
+        maxLength: 64
+        description: AS id
+      neighbor-as:
+        type: string
+        maxLength: 64
+        description: AS id
+      neighbor:
+        type: string
+        maxLength: 15
+        description: Bgp  neighbor
+        pattern: ^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})?$
+  Bgps:
+    type: array
+    items:
+      type: Bgp
+  upd_Bgp:
+    type: Bgp
+  inspect_Bgp:
+    properties:
+      Config:
+        type: Bgp
+      Oper:
+        properties:
+          numRoutes:
+            type: integer
+            description: number of routes
+          neighborStatus:
+            type: string
+            description: neighbor status
+          adminStatus:
+            type: string
+            description: admin status
+          routes:
+            type: array
+            items:
+              type: string
+            description: routes
+  endpoint:
+    properties: {}
+  endpoints:
+    type: array
+    items:
+      type: endpoint
+  upd_endpoint:
+    type: endpoint
+  inspect_endpoint:
+    properties:
+      Config:
+        type: endpoint
+      Oper:
+        properties:
+          network:
+            type: string
+          endpointID:
+            type: string
+          serviceName:
+            type: string
+          endpointGroupId:
+            type: integer
+          endpointGroupKey:
+            type: string
+          ipAddress:
+            type: array
+            items:
+              type: string
+          macAddress:
+            type: string
+          homingHost:
+            type: string
+          intfName:
+            type: string
+          vtepIP:
+            type: string
+          labels:
+            type: string
+          containerID:
+            type: string
+          containerName:
+            type: string
+          virtualPort:
+            type: string
+  endpointGroup:
+    properties:
+      groupName:
+        type: string
+        maxLength: 64
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      tenantName:
+        type: string
+        maxLength: 64
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      networkName:
+        type: string
+        maxLength: 64
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      policies:
+        type: array
+        items:
+          type: string
+      extContractsGrps:
+        type: array
+        items:
+          type: string
+      netProfile:
+        type: string
+  endpointGroups:
+    type: array
+    items:
+      type: endpointGroup
+  upd_endpointGroup:
+    type: endpointGroup
+  inspect_endpointGroup:
+    properties:
+      Config:
+        type: endpointGroup
+      Oper:
+        properties:
+          pktTag:
+            type: integer
+            description: internal packet tag
+          externalPktTag:
+            type: integer
+            description: external packet tag
+          numEndpoints:
+            type: integer
+            description: number of endpoints
+          endpoints:
+            type: array
+            items:
+              type: endpoint
+            description: endpoints in the group
+  extContractsGroup:
+    properties:
+      tenantName:
+        type: string
+        maxLength: 64
+        description: Tenant name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      contractsGroupName:
+        type: string
+        maxLength: 64
+        description: Contracts group name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      contractsType:
+        type: string
+        description: Contracts type
+      contracts:
+        type: array
+        items:
+          type: string
+        description: Contracts list
+  extContractsGroups:
+    type: array
+    items:
+      type: extContractsGroup
+  upd_extContractsGroup:
+    type: extContractsGroup
+  inspect_extContractsGroup:
+    properties:
+      Config:
+        type: extContractsGroup
+  global:
+    properties:
+      name:
+        type: string
+        maxLength: 64
+        description: name of this block(must be 'global')
+        pattern: ^(global)$
+      networkInfraType:
+        type: string
+        maxLength: 64
+        description: Network infrastructure type
+        pattern: ^(aci|aci-opflex|default)?$
+      vlans:
+        type: string
+        description: Allowed vlan range
+        pattern: ^([0-9]{1,4}?-[0-9]{1,4}?)$
+      vxlans:
+        type: string
+        description: Allwed vxlan range
+        pattern: ^([0-9]{1,8}?-[0-9]{1,8}?)$
+      fwdMode:
+        type: string
+        maxLength: 64
+        description: Forwarding Mode
+        pattern: ^(bridge|routing)?$
+      arpMode:
+        type: string
+        maxLength: 64
+        description: ARP Mode
+        pattern: ^(proxy|flood)?$
+      pvtSubnet:
+        type: string
+        description: Private Subnet used by host bridge
+        pattern: ^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})/16$
+  globals:
+    type: array
+    items:
+      type: global
+  upd_global:
+    type: global
+  inspect_global:
+    properties:
+      Config:
+        type: global
+      Oper:
+        properties:
+          numNetworks:
+            type: integer
+          defaultNetwork:
+            type: string
+          vlansInUse:
+            type: string
+          vxlansInUse:
+            type: string
+          freeVXLANsStart:
+            type: integer
+          clusterMode:
+            type: string
+  netprofile:
+    properties:
+      profileName:
+        type: string
+        maxLength: 64
+        description: Network profile name
+      tenantName:
+        type: string
+        description: Tenant name
+      bandwidth:
+        type: string
+        maxLength: 64
+        description: Allocated bandwidth
+        pattern: ^([1-9][0-9]* (([kmgKMG{1}]bps)|[kmgKMG{1}]|(kb|Kb|Gb|gb|Mb|mb)))?$|^([1-9][0-9]*(((k|m|g|K|G|M)bps)|(k|m|g|K|M|G)|(kb|Kb|Gb|gb|Mb|mb)))?$
+      DSCP:
+        type: integer
+        description: DSCP
+      burst:
+        type: integer
+        description: burst size
+  netprofiles:
+    type: array
+    items:
+      type: netprofile
+  upd_netprofile:
+    type: netprofile
+  inspect_netprofile:
+    properties:
+      Config:
+        type: netprofile
+  network:
+    properties:
+      networkName:
+        type: string
+        maxLength: 64
+        description: Network name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      tenantName:
+        type: string
+        maxLength: 64
+        description: Tenant Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      nwType:
+        type: string
+        description: Network Type
+        pattern: ^(infra|data)$
+      encap:
+        type: string
+        description: Encapsulation
+        pattern: ^(vlan|vxlan)$
+      pktTag:
+        type: integer
+        description: Vlan/Vxlan Tag
+      subnet:
+        type: string
+        description: Subnet
+        pattern: ^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})(\\-((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3}))?/(3[0-1]|2[0-9]|1[0-9]|[1-9])$
+      gateway:
+        type: string
+        description: Gateway
+        pattern: ^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})?$
+      ipv6Subnet:
+        type: string
+        description: IPv6Subnet
+        pattern: ^((((([0-9]|[a-f]|[A-F]){1,4})((\\:([0-9]|[a-f]|[A-F]){1,4}){7}))|(((([0-9]|[a-f]|[A-F]){1,4}\\:){0,6}|\\:)((\\:([0-9]|[a-f]|[A-F]){1,4}){0,6}|\\:)))/(1[0-2][0-7]|[1-9][0-9]|[1-9]))?$
+      ipv6Gateway:
+        type: string
+        description: IPv6Gateway
+        pattern: ^(((([0-9]|[a-f]|[A-F]){1,4})((\\:([0-9]|[a-f]|[A-F]){1,4}){7}))|(((([0-9]|[a-f]|[A-F]){1,4}\\:){0,6}|\\:)((\\:([0-9]|[a-f]|[A-F]){1,4}){0,6}|\\:)))?$
+  networks:
+    type: array
+    items:
+      type: network
+  upd_network:
+    type: network
+  inspect_network:
+    properties:
+      Config:
+        type: network
+      Oper:
+        properties:
+          pktTag:
+            type: integer
+            description: internal packet tag
+          externalPktTag:
+            type: integer
+            description: external packet tag
+          numEndpoints:
+            type: integer
+            description: external packet tag
+          allocatedAddressesCount:
+            type: integer
+            description: Vlan/Vxlan Tag
+          allocatedIPAddresses:
+            type: string
+            description: allocated IP addresses
+          availableIPAddresses:
+            type: string
+            description: Available IP addresses
+          endpoints:
+            type: array
+            items:
+              type: endpoint
+            description: endpoints in the network
+  policy:
+    properties:
+      policyName:
+        type: string
+        maxLength: 64
+        description: Policy Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      tenantName:
+        type: string
+        maxLength: 64
+        description: Tenant Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+  policys:
+    type: array
+    items:
+      type: policy
+  upd_policy:
+    type: policy
+  inspect_policy:
+    properties:
+      Config:
+        type: policy
+      Oper:
+        properties:
+          numEndpoints:
+            type: integer
+            description: number of endpoints
+          policyViolations:
+            type: integer
+            description: number of policyViolations
+          endpoints:
+            type: array
+            items:
+              type: endpoint
+            description: endpoints associate with the policy
+  rule:
+    properties:
+      tenantName:
+        type: string
+        maxLength: 64
+        description: Tenant Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      policyName:
+        type: string
+        maxLength: 64
+        description: Policy Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      ruleId:
+        type: string
+        maxLength: 64
+        description: Rule Id
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      direction:
+        type: string
+        description: Direction
+        pattern: ^(in|out)$
+      priority:
+        type: integer
+        description: Priority
+      fromEndpointGroup:
+        type: string
+        maxLength: 64
+        description: From Endpoint Group
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])?$
+      toEndpointGroup:
+        type: string
+        maxLength: 64
+        description: To Endpoint Group
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])?$
+      fromNetwork:
+        type: string
+        maxLength: 64
+        description: From Network
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])?$
+      toNetwork:
+        type: string
+        maxLength: 64
+        description: To Network
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])?$
+      fromIpAddress:
+        type: string
+        description: IP Address
+        pattern: ^(((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})(\\-(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))?(/(3[0-1]|2[0-9]|1[0-9]|[1-9]))?)?$
+      toIpAddress:
+        type: string
+        description: IP Address
+        pattern: ^(((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})(\\-(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9]))?(/(3[0-1]|2[0-9]|1[0-9]|[1-9]))?)?$
+      protocol:
+        type: string
+        description: Protocol
+        pattern: ^(tcp|udp|icmp||[0-9]{1,3}?)$
+      port:
+        type: integer
+        description: Port No
+      action:
+        type: string
+        description: Action
+        pattern: ^(allow|deny)$
+  rules:
+    type: array
+    items:
+      type: rule
+  upd_rule:
+    type: rule
+  inspect_rule:
+    properties:
+      Config:
+        type: rule
+  serviceLB:
+    properties:
+      tenantName:
+        type: string
+        maxLength: 64
+        description: Tenant Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      networkName:
+        type: string
+        maxLength: 64
+        description: Service network name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      serviceName:
+        type: string
+        maxLength: 256
+        description: service name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      ipAddress:
+        type: string
+        maxLength: 15
+        description: Service ip
+        pattern: ^((25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])(\\.(25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])){3})?$
+      selectors:
+        type: array
+        items:
+          type: string
+        description: labels key value pair
+      ports:
+        type: array
+        items:
+          type: string
+        description: service provider port
+  serviceLBs:
+    type: array
+    items:
+      type: serviceLB
+  upd_serviceLB:
+    type: serviceLB
+  inspect_serviceLB:
+    properties:
+      Config:
+        type: serviceLB
+      Oper:
+        properties:
+          serviceVip:
+            type: string
+            description: allocated IP addresses
+          numProviders:
+            type: integer
+            description: ' number of provider endpoints for the service'
+          providers:
+            type: array
+            items:
+              type: endpoint
+            description: provider endpoints for the service
+  tenant:
+    properties:
+      tenantName:
+        type: string
+        maxLength: 64
+        description: Tenant Name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$
+      defaultNetwork:
+        type: string
+        maxLength: 64
+        description: Network name
+        pattern: ^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])?$
+  tenants:
+    type: array
+    items:
+      type: tenant
+  upd_tenant:
+    type: tenant
+  inspect_tenant:
+    properties:
+      Config:
+        type: tenant
+      Oper:
+        properties:
+          totalNetworks:
+            type: integer
+            description: total number of networks
+          totalEPGs:
+            type: integer
+            description: total number of EPGs
+          totalNetprofiles:
+            type: integer
+            description: total number of Netprofiles
+          totalAppProfiles:
+            type: integer
+            description: total number of App-Profiles
+          totalServicelbs:
+            type: integer
+            description: total number of Servicelbs
+          totalPolicies:
+            type: integer
+            description: total number of totalPolicies
+          totalEndpoints:
+            type: integer
+            description: total number of endpoints in the tenant
+          endpoints:
+            type: array
+            items:
+              type: endpoint
+            description: endpoints in the tenant
+          networks:
+            type: array
+            items:
+              type: network
+            description: networks in the tenant
+          endpointGroups:
+            type: array
+            items:
+              type: endpointGroup
+            description: endpointGroups in the tenant
+          policies:
+            type: array
+            items:
+              type: policy
+            description: policies in the tenant
+          servicelbs:
+            type: array
+            items:
+              type: serviceLB
+            description: servicelbs in the tenant
+  volume:
+    properties:
+      volumeName:
+        type: string
+        description: Volume Name
+      tenantName:
+        type: string
+        description: Tenant Name
+      datastoreType:
+        type: string
+      poolName:
+        type: string
+      size:
+        type: string
+      mountPoint:
+        type: string
+  volumes:
+    type: array
+    items:
+      type: volume
+  upd_volume:
+    type: volume
+  inspect_volume:
+    properties:
+      Config:
+        type: volume
+  volumeProfile:
+    properties:
+      volumeProfileName:
+        type: string
+        description: Volume profile Name
+      tenantName:
+        type: string
+        description: Tenant Name
+      datastoreType:
+        type: string
+      poolName:
+        type: string
+      size:
+        type: string
+      mountPoint:
+        type: string
+  volumeProfiles:
+    type: array
+    items:
+      type: volumeProfile
+  upd_volumeProfile:
+    type: volumeProfile
+  inspect_volumeProfile:
+    properties:
+      Config:
+        type: volumeProfile

--- a/spec/contiv/schemas/collection-item.raml
+++ b/spec/contiv/schemas/collection-item.raml
@@ -1,0 +1,46 @@
+#%RAML 1.0 ResourceType
+description: Entity representing <<resourcePathName|!singularize>>
+get:
+  description: returns <<resourcePathName|!singularize>>.
+  responses:
+    200:
+      body:
+        application/json:
+          type: <<provider>>.<<resourcePathName|!singularize>>
+    404:
+      body:
+        application/json: |
+          {"message": "<<resourcePathName|!singularize>> not found" }
+patch:
+  description: updates <<resourcePathName|!singularize>>.
+  body:
+    application/json: 
+      type: <<provider>>.upd_<<resourcePathName|!singularize>>
+  responses:
+    200:
+      body:
+        application/json:
+          type: <<provider>>.<<resourcePathName|!singularize>>
+    404:
+      body:
+        application/json: |
+          {"message": "<<resourcePathName|!singularize>> not found" }
+delete:
+  description: deletes <<resourcePathName|!singularize>>.
+  responses:
+    204:
+put?:
+  description: updates/creates <<resourcePathName|!singularize>>
+  body:
+    application/json: 
+      type: <<provider>>.upd_<<resourcePathName|!singularize>>
+  responses:
+    200:
+      body:
+        application/json:
+          type: <<provider>>.<<resourcePathName|!singularize>>
+    404:
+      body:
+        application/json: |
+          {"message": "<<resourcePathName|!singularize>> not found" }
+

--- a/spec/contiv/schemas/collection.raml
+++ b/spec/contiv/schemas/collection.raml
@@ -1,0 +1,17 @@
+#%RAML 1.0 ResourceType
+description: A collection of <<resourcePathName>>
+get:
+  description: returns a list of <<resourcePathName|!singularize>>.
+  responses:
+    200:
+      body:
+        application/json:
+          type: <<provider>>.<<resourcePathName>>
+post:
+  description: Add a new <<resourcePathName|!singularize>>.
+  body:
+    application/json:
+      type: <<provider>>.<<resourcePathName|!singularize>>
+  responses:
+    201:
+    404:

--- a/spec/contiv/schemas/custom-scheme.raml
+++ b/spec/contiv/schemas/custom-scheme.raml
@@ -1,0 +1,19 @@
+#%RAML 1.0 SecurityScheme
+
+description: |
+  A custom security scheme for authenticating requests.
+type: x-custom
+describedBy:
+  headers:
+    X-Auth-Token:
+      description: |
+        Used to send a custom token. Obtained via /login API.
+      type: string
+  responses:
+    401:
+      description: |
+        Authentication failed.
+    403:
+      description: | 
+        Forbidden.
+

--- a/spec/contiv/schemas/non-upd-collection-item.raml
+++ b/spec/contiv/schemas/non-upd-collection-item.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0 ResourceType
+description: Entity representing <<resourcePathName|!singularize>>
+get:
+  description: returns <<resourcePathName|!singularize>>.
+  responses:
+    200:
+      body:
+        application/json:
+          type: <<provider>>.<<resourcePathName|!singularize>>
+    404:
+      body:
+        application/json: |
+          {"message": "<<resourcePathName|!singularize>> not found" }
+delete:
+  description: deletes <<resourcePathName|!singularize>>.
+  responses:
+    204:
+

--- a/spec/contiv/schemas/ro-collection-item.raml
+++ b/spec/contiv/schemas/ro-collection-item.raml
@@ -1,0 +1,13 @@
+#%RAML 1.0 ResourceType
+description: Entity representing <<resourcePathName|!singularize>>
+get:
+  description: returns <<resourcePathName|!singularize>>.
+  responses:
+    200:
+      body:
+        application/json:
+          type: <<provider>>.inspect_<<resourcePathName|!singularize>>
+    404:
+      body:
+        application/json: |
+          {"message": "<<resourcePathName|!singularize>> not found" }

--- a/spec/contivModel2raml.rb
+++ b/spec/contivModel2raml.rb
@@ -1,0 +1,119 @@
+# This utility converts contiv object model definition in json format to raml format, which is essentially
+# yaml with strict syntax.
+require "json"
+require "yaml"
+
+outfile = "netmaster.raml"
+output = Hash.new { |h, k| h[k] = {} }
+
+Dir["../*.json"].each do |infile|
+
+  puts infile
+
+  data = JSON.parse(File.read(infile))
+
+  object = data["objects"][0]
+
+  # autovivification... allows assignment at any depth without declaring each key as a new hash
+  properties = Hash.new { |h, k| h[k] = {} }
+
+  if object["cfgProperties"]
+    
+    # for each entry under "cfgProperties", copy the relevant entries to the new
+    # properties hash, changing key names as necessary.
+    object["cfgProperties"].each do |name, value|
+      p = properties[name]
+    
+      if value["type"] == "int"
+        p["type"] = "integer"
+      else
+        p["type"] = value["type"]
+      end
+
+      if p["type"] == "array"
+        p["items"] = {
+		"type" => value["items"]
+	}
+      end
+
+      if value["length"] && value["type"] == "string"
+        p["maxLength"] = value["length"]
+      end
+
+      if value["title"]
+        p["description"] = value["title"]
+      end 
+
+      if value["format"]
+        p["pattern"] = value["format"]
+      end
+
+    end
+    
+  end
+  
+  # insert properties into desired output structure
+  output["types"][object["name"]] = {
+        "properties" => properties
+  }
+  output["types"][object["name"]+"s"] = {
+        "type" => "array",
+        "items" => {
+	  "type" => object["name"]
+	}
+  }
+  # update structure, used with put/patch on main route
+  #
+  output["types"]["upd_"+object["name"]] = {
+         "type" => object["name"]
+  }
+  # inspect structure, contains operational and config properties
+  output["types"]["inspect_"+object["name"]] = {
+        "properties" => {
+          "Config" => {
+  	    "type" => object["name"]
+  	    }
+        }
+  }
+  
+  if object["operProperties"]
+  
+    opProperties = Hash.new { |h, k| h[k] = {} }
+  
+    object["operProperties"].each do |name, value|
+      p = opProperties[name]
+
+      if value["type"] == "int"
+        p["type"] = "integer"
+      else
+        p["type"] = value["type"]
+      end
+
+      if p["type"] == "array"
+        p["items"] = {
+		"type" => value["items"]
+	}   
+      end
+
+      if value["length"] && value["type"] == "string"
+        p["maxLength"] = value["length"]
+      end
+
+      if value["title"]
+        p["description"] = value["title"]
+      end
+
+      if value["format"]
+        p["pattern"] = value["format"]
+      end
+    
+    end
+  
+    # add operational properties if present
+    output["types"]["inspect_"+object["name"]]["properties"]["Oper"] = { "properties" => opProperties }
+
+  end
+  
+end
+
+File.write(outfile, output.to_yaml.gsub("---", "#%RAML 1.0 Library"))


### PR DESCRIPTION
1. Auto generation of netmaster.raml from contivModel specification.
This file is generated using contivModel2raml.rb, and needs to be put in
contiv/libraries.
2. Authored contiv.raml specification
3. Authored auth_proxy.raml specification
4. To generate contiv.html, run raml2html utility as follows:

   raml2html -i contiv.raml -o contiv.html

   On MacOS X, raml2html can be installed via npm as:
   npm install -g raml2html

Signed-off-by: Himanshu Raj <rhim@users.noreply.github.com>