### PR TITLE
scripts/build.sh: disabled regeneration of RAML-based documentation which is currently failing due to atrophy

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,6 +7,11 @@ bash generate.sh
 go install ./ ./client/
 
 # update the docs based on the latest code
-pushd spec
-make docs
-popd
+
+# NOTE: disabled on 2017/06/27 due to a breakage in the RAML Dockerfile.  it's complaining
+#       about a xhr2 package being missing or something.  since we're not even using the
+#       generated documentation, disabling it is the best option for now.
+
+# pushd spec
+# make docs
+# popd


### PR DESCRIPTION
Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>